### PR TITLE
Tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Default: `{tag}`
 
 The name of the release. By default it will use the tag name. `{tag}` is a placeholder and can be used inside another string.
 
+#### options.tag
+Type: `String`
+
+Default: `undefined`
+
+The tag for which ti do a release. By default, will fetch the latest tag from Github.
+
 ### Usage Examples
 
 ```js

--- a/tasks/github_release_asset.js
+++ b/tasks/github_release_asset.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
 				if (fs.existsSync(options.file)) {
 					hub.getLatestTag(callback);
 				} else {
-					grunt.fail.fatal('File doesn\'t exist (' + options.file + ')');
+					throw 'File doesn\'t exist (' + options.file + ')';
 				}
 			},
 			function (body, callback) {
@@ -63,7 +63,7 @@ module.exports = function (grunt) {
 			function (body, callback) {
 				if (body.errors) {
 					var msg = body.message + (body.errors.length > 0? '(' + body.errors[0].code + ')' : '');
-					grunt.fail.fatal(msg);
+					throw msg;
 				}
 				grunt.log.ok('Uploading asset: ' + options.file + '...');
 				hub.uploadAsset(body.id, options.file, callback);

--- a/tasks/github_release_asset.js
+++ b/tasks/github_release_asset.js
@@ -42,18 +42,29 @@ module.exports = function (grunt) {
 		async.waterfall([
 
 			function (callback) {
-				if (fs.existsSync(options.file)) {
-					hub.getLatestTag(callback);
-				} else {
+				if (!fs.existsSync(options.file)) {
 					throw 'File doesn\'t exist (' + options.file + ')';
 				}
+				callback(null);
 			},
-			function (body, callback) {
-				if (body.length === 0) {
-					grunt.fail.fatal('No tag was found.');
+			function (callback) {
+				var tag;
+				if (!options.tag) {
+					return hub.getLatestTag(function (err, body) {
+						if (err) {
+							return callback(err);
+						}
+						try {
+							callback(null, body[0].name);
+						} catch (e) {
+							callback(new Error('No tags for this repo'));
+						}
+					});
+				} else {
+					callback(null, options.tag);
 				}
-				var tag = body[0].name;
-
+			},
+			function (tag, callback) {
 				var releaseName = format(options.releaseName, {
 					tag: tag
 				});


### PR DESCRIPTION
Adds an `options.tag` entry that can be used to specify the tag to push a release to. instead of relying on the first tag returned by the API.
